### PR TITLE
fixed gpu error

### DIFF
--- a/ROS/src/ur3_moveit/src/ur3_moveit/setup_and_run_model.py
+++ b/ROS/src/ur3_moveit/src/ur3_moveit/setup_and_run_model.py
@@ -135,7 +135,7 @@ def run_model_main(image_file_png, model_file_name):
 
     image = pre_process_image(image_file_png, device)
     output_translation, output_orientation = model(torch.stack(image).reshape(-1, 3, 224, 224))
-    output_translation, output_orientation = output_translation.detach().numpy(), output_orientation.detach().numpy()
+    output_translation, output_orientation = output_translation.cpu().detach().numpy(), output_orientation.cpu().detach().numpy()
     return output_orientation, output_translation
 
 # def run_model_main():


### PR DESCRIPTION
#52 modification still cause following error.
->
`Error processing request: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.`

So we need to convert output type to cpu from gpu.

Note:
If you use docker environment, please add -`-gpus all` option.

```
docker run -it --rm --gpus all -p 10000:10000 -p 5005:5005 unity-robotics:pose-estimation /bin/bash
```
You can also use `nvidia-smi` command in docker whether gpu is enable or not.
